### PR TITLE
Output coupling

### DIFF
--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -58,17 +58,24 @@ optSim.run
 
 %% Test Plots
 fh1 = figure("Position",[10, 10, 1000, 600]);
-tiledlayout(2,2,'TileSpacing','compact')
+tiledlayout(3,2,'TileSpacing','compact')
+xlims = [700 1700];
+
 nexttile
-laser.Pulse.kplot([700 1700])
+laser.Pulse.kplot(xlims)
 nexttile
 laser.Pulse.tplot
+
 nexttile
-% sLaser.Pulse.kplot([750 900])
-optSim.Pulse.kplot([700 1700])
+optSim.Pulse.kplot(xlims)
 nexttile
-% sLaser.Pulse.tplot
 optSim.Pulse.tplot
+
+nexttile
+optSim.OutputPulse.kplot(xlims)
+nexttile
+optSim.OutputPulse.tplot
+
 
 figure
 cav.Optics.xtal.xtalplot

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -15,8 +15,8 @@ rng('default');
 
 
 %% Initialise Optical Cavity
-% load('pbCav.mat');t
-load('pbCavAiry.mat');
+load('pbCav.mat');
+% load('pbCavAiry.mat');
 % cav.Xtal.Chi2 = 0;
 cav.Xtal.GratingPeriod = 21.32e-6;
 

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -77,6 +77,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 
 			obj.Source.Pulse.applyGDD(obj.System.PumpChirp);
 			obj.Pulse = copy(obj.Source.Pulse);	% Copy the pump pulse as basis for cavity field
+			obj.Pulse.Name = "Intracavity Pulse";
 			refresh(obj);
 		end
 
@@ -113,7 +114,9 @@ classdef OpticalSim < matlab.mixin.Copyable
 			airOpt = obj.Pulse.Medium;
 			dt = obj.SimWin.DeltaTime;
 			obj.TripNumber = 0;
+
 			obj.OutputPulse = copy(obj.Pulse);
+			obj.OutputPulse.Name = "Combined Transmitted Pulse";
 
 			while obj.TripNumber < obj.RoundTrips
 				obj.TripNumber = obj.TripNumber + 1;
@@ -144,12 +147,11 @@ classdef OpticalSim < matlab.mixin.Copyable
 
 				obj.Pulse.TemporalField = fftshift(EtShift.');
 				obj.OutputPulse.TemporalField = obj.Pulse.TemporalField;
+			
 				% obj.Pulse.refract(airOpt);
-
 				obj.Pulse.propagate(obj.System.Optics);
-
 				obj.Pulse.refract(airOpt);
-
+				obj.OutputPulse.minus(obj.Pulse);
 				obj.Pulse.applyGD(obj.Delay);
 
 				obj.pump;

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -23,6 +23,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 		ProgressPlots = 4;
 	end
 	properties (Transient)
+		OutputPulse	OpticalPulse	% Pulse object to store what exits the cavity each trip
 		Hardware = "CPU"
 		TripNumber = 0;
 		StepSizeModifiers
@@ -98,7 +99,6 @@ classdef OpticalSim < matlab.mixin.Copyable
 		% Should probably convert to correct precision and array type in the setup
 			
 			xtal = obj.System.Xtal;
-			% sel = obj.convArr(round(xtal.NSteps/(obj.ProgressPlots - 1)));
 			sel = (round(xtal.NSteps/(obj.ProgressPlots - 1)));
 			n0 = xtal.Bulk.RefractiveIndex(obj.SimWin.ReferenceIndex);
 			w0 = obj.convArr(obj.SimWin.ReferenceOmega);
@@ -113,7 +113,8 @@ classdef OpticalSim < matlab.mixin.Copyable
 			airOpt = obj.Pulse.Medium;
 			dt = obj.SimWin.DeltaTime;
 			obj.TripNumber = 0;
-			
+			obj.OutputPulse = copy(obj.Pulse);
+
 			while obj.TripNumber < obj.RoundTrips
 				obj.TripNumber = obj.TripNumber + 1;
 				
@@ -142,8 +143,8 @@ classdef OpticalSim < matlab.mixin.Copyable
 				obj.Plotter.updateplots(obj);
 
 				obj.Pulse.TemporalField = fftshift(EtShift.');
-				
-				obj.Pulse.refract(airOpt);
+				obj.OutputPulse.TemporalField = obj.Pulse.TemporalField;
+				% obj.Pulse.refract(airOpt);
 
 				obj.Pulse.propagate(obj.System.Optics);
 

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -64,8 +64,8 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			for ii = 1:width(opt_tbl)
 				% optAir = obj.Medium;
 				opt = opt_tbl.(ii);
-				obj.refract(opt);
-				Ek = obj.SpectralField;
+				Ek = obj.refract(opt);
+				% Ek = obj.SpectralField;
 				if ii ~= opt.Parent.CrystalPosition
 					bOp = exp(-1i*opt.Dispersion);
 				end
@@ -74,6 +74,14 @@ classdef OpticalPulse < matlab.mixin.Copyable
 				% obj.refract(optAir);
 			    obj.k2t(Ek);
 			end
+		end
+
+		function Ek = refract(obj,optic2)
+			nr1 = obj.Medium.Bulk.RefractiveIndex;
+			obj.Medium = optic2;
+			nr2 = obj.Medium.Bulk.RefractiveIndex;
+			Ek = obj.SpectralField .* abs(sqrt(nr1./nr2));
+			obj.k2t(Ek);
 		end
 
 		function lam_max = get.PeakWavelength(obj)
@@ -85,14 +93,6 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			Ek = obj.SpectralField;
 			wPump = 2*pi*c / obj.PeakWavelength;
 			Ek = Ek .* exp(-1i.*(obj.SimWin.Omegas-wPump).*obj.SimWin.TimeOffset);
-			obj.k2t(Ek);
-		end
-
-		function refract(obj,optic2)
-			nr1 = obj.Medium.Bulk.RefractiveIndex;
-			obj.Medium = optic2;
-			nr2 = obj.Medium.Bulk.RefractiveIndex;
-			Ek = obj.SpectralField .* abs(sqrt(nr1./nr2));
 			obj.k2t(Ek);
 		end
 


### PR DESCRIPTION
Initial implementation of an output pulse within the OpticalSim class. Currently this just finds the difference between the intracavity pulse before and after propagation through all non-crystal optics.