### PR TITLE
Pulse duration rework

### DIFF
--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -41,7 +41,7 @@ simWin.TimeOffset = -0.5e-12;
 optSim = OpticalSim(laser,cav,simWin,[0.2,4],0.25e-6);
 % return
 % load('pbOPOsim.mat');
-optSim.RoundTrips = 50;
+optSim.RoundTrips = 80;
 % optSim.Hardware = "CPU";
 optSim.setup;
 

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -149,9 +149,9 @@ classdef OpticalSim < matlab.mixin.Copyable
 				obj.Plotter.updateplots(obj);
 
 				obj.Pulse.TemporalField = fftshift(EtShift.');
+				obj.Pulse.refract(airOpt);
 				obj.OutputPulse.TemporalField = obj.Pulse.TemporalField;
 			
-				% obj.Pulse.refract(airOpt);
 				obj.Pulse.propagate(obj.System.Optics);
 				obj.Pulse.refract(airOpt);
 				obj.OutputPulse.minus(obj.Pulse);

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -114,7 +114,10 @@ classdef OpticalPulse < matlab.mixin.Copyable
 		end
 
 		function minus(obj,pulse)
-			obj.TemporalField = obj.TemporalField - pulse.TemporalField;
+			EkMag = abs(obj.SpectralField) - abs(pulse.SpectralField);
+			EkPhase = unwrap(angle(obj.SpectralField));
+			Ek = EkMag .* exp(1i * EkPhase);
+			obj.k2t(Ek)
 		end
 
 		function lam_max = get.PeakWavelength(obj)

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -110,7 +110,10 @@ classdef OpticalPulse < matlab.mixin.Copyable
 		end
 
 		function add(obj,pulse)
-			obj.TemporalField = obj.TemporalField + pulse.TemporalField;
+			EkMag = abs(obj.SpectralField) + abs(pulse.SpectralField);
+			EkPhase = unwrap(angle(obj.SpectralField));
+			Ek = EkMag .* exp(1i * EkPhase);
+			obj.k2t(Ek)
 		end
 
 		function minus(obj,pulse)

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -33,7 +33,6 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			obj.Medium.simulate(simWin);
 			obj.SimWin = simWin;
 			obj.Source = laser;
-			obj.Duration = laser.PulseDuration;
 			t = simWin.Times;
 			t_off = simWin.TimeOffset;
 			str = laser.SourceString;
@@ -51,8 +50,10 @@ classdef OpticalPulse < matlab.mixin.Copyable
 									simWin.Omegas,laser.PhaseString);
 			end
 			
-			if obj.Duration < obj.DurationTL
+			if laser.PulseDuration < obj.DurationTL
 				obj.Duration = obj.DurationTL;
+			else
+				obj.Duration = laser.PulseDuration;
 			end
 			% Shift the pulse by simWin.TimeOffset
 			obj.timeShift;


### PR DESCRIPTION
Fixed calculation of transform limited pulse durations for pulses with experimentally determined phase information. 
Improved encapsulation of OpticalPulse class (still a fair bit more to be done).
Added PumpPulse property to OpticalSim to allow propagation through pre-cavity optics without altering the source directly.