### PR TITLE
Output Coupling implementation and fixes

### DIFF
--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -35,9 +35,9 @@ load('GigajetTiSapph.mat');
 load('simWin.mat');
 %%% then customise simulation window properties if required:
 % simWin.Limits = [300 5500];
-% simWin.TemporalRange = simWin.TemporalRange * 2;
+simWin.TemporalRange = simWin.TemporalRange * 2;
 % simWin.TimeOffset = -1.5e-12;
-% simWin.NumberOfPoints = 2^17;
+simWin.NumberOfPoints = 2^17;
 
 %% Optical Simulation Setup
 optSim = OpticalSim(laser,cav,simWin,[0.2,4],0.25e-6);

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -35,9 +35,9 @@ load('GigajetTiSapph.mat');
 load('simWin.mat');
 %%% then customise simulation window properties if required:
 % simWin.Limits = [300 5500];
-simWin.TemporalRange = simWin.TemporalRange * 2;
+% simWin.TemporalRange = simWin.TemporalRange * 2;
 % simWin.TimeOffset = -1.5e-12;
-simWin.NumberOfPoints = 2^17;
+% simWin.NumberOfPoints = 2^17;
 
 %% Optical Simulation Setup
 optSim = OpticalSim(laser,cav,simWin,[0.2,4],0.25e-6);

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -34,7 +34,7 @@ load('GigajetTiSapph.mat');
 %%% or load in an existing simulation window:
 load('simWin.mat');
 %%% then customise simulation window properties if required:
-% simWin.Limits = [350 5500];
+simWin.Limits = [300 5500];
 simWin.TemporalRange = simWin.TemporalRange / 2;
 simWin.TimeOffset = -1.5e-12;
 simWin.NumberOfPoints = 2^18;

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -34,10 +34,10 @@ load('GigajetTiSapph.mat');
 %%% or load in an existing simulation window:
 load('simWin.mat');
 %%% then customise simulation window properties if required:
-simWin.Limits = [300 5500];
-% simWin.TemporalRange = simWin.TemporalRange / 2;
+% simWin.Limits = [300 5500];
+simWin.TemporalRange = simWin.TemporalRange * 2;
 % simWin.TimeOffset = -1.5e-12;
-% simWin.NumberOfPoints = 2^18;
+simWin.NumberOfPoints = 2^17;
 
 %% Optical Simulation Setup
 optSim = OpticalSim(laser,cav,simWin,[0.2,4],0.25e-6);
@@ -46,6 +46,7 @@ optSim = OpticalSim(laser,cav,simWin,[0.2,4],0.25e-6);
 optSim.RoundTrips = 40;
 % optSim.Hardware = "CPU";
 % optSim.ProgressPlotting = 0;
+% optSim.DetectorPosition = 3;
 optSim.setup;
 
 % optSim.PumpPulse.plot

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -35,9 +35,9 @@ load('GigajetTiSapph.mat');
 load('simWin.mat');
 %%% then customise simulation window properties if required:
 simWin.Limits = [300 5500];
-simWin.TemporalRange = simWin.TemporalRange / 2;
-simWin.TimeOffset = -1.5e-12;
-simWin.NumberOfPoints = 2^18;
+% simWin.TemporalRange = simWin.TemporalRange / 2;
+% simWin.TimeOffset = -1.5e-12;
+% simWin.NumberOfPoints = 2^18;
 
 %% Optical Simulation Setup
 optSim = OpticalSim(laser,cav,simWin,[0.2,4],0.25e-6);

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -35,8 +35,8 @@ load('GigajetTiSapph.mat');
 load('simWin.mat');
 %%% then customise simulation window properties if required:
 % simWin.Limits = [350 5500];
-simWin.TemporalRange = simWin.TemporalRange * 2;
-simWin.TimeOffset = -0.25e-12;
+simWin.TemporalRange = simWin.TemporalRange / 2;
+simWin.TimeOffset = -1.0e-12;
 simWin.NumberOfPoints = 2^18;
 
 %% Optical Simulation Setup

--- a/toolbox/OPO_sim_OOP.m
+++ b/toolbox/OPO_sim_OOP.m
@@ -36,7 +36,7 @@ load('simWin.mat');
 %%% then customise simulation window properties if required:
 % simWin.Limits = [350 5500];
 simWin.TemporalRange = simWin.TemporalRange / 2;
-simWin.TimeOffset = -1.0e-12;
+simWin.TimeOffset = -1.5e-12;
 simWin.NumberOfPoints = 2^18;
 
 %% Optical Simulation Setup

--- a/toolbox/lib/classes/Cavity.m
+++ b/toolbox/lib/classes/Cavity.m
@@ -45,12 +45,14 @@ classdef Cavity < handle
 				opt = obj.PreCavityOptics.(ii);
 				opt.Parent = obj;
 				opt.simulate(obj.SimWin);
+				opt.Name = obj.PreCavityOptics.Properties.VariableNames(ii);
 				obj.PumpDispersion = obj.PumpDispersion + opt.Dispersion;
 			end
 			for ii = 1:width(obj.Optics)
 				opt = obj.Optics.(ii);
 				opt.Parent = obj;
 				opt.simulate(obj.SimWin);
+				opt.Name = obj.Optics.Properties.VariableNames(ii);
 				obj.Transmission = obj.Transmission .* opt.Transmission;
 				obj.Dispersion = obj.Dispersion + opt.Dispersion;
 				obj.GroupDelay = obj.GroupDelay + opt.GroupDelay;

--- a/toolbox/lib/classes/Optic.m
+++ b/toolbox/lib/classes/Optic.m
@@ -14,6 +14,8 @@ classdef Optic < matlab.mixin.Copyable
 	properties (Transient)
 		SimWin		SimWindow
 		Transmission
+		Reflection
+		Absorption
 		Dispersion
 	end
 	properties (Dependent)
@@ -69,17 +71,20 @@ classdef Optic < matlab.mixin.Copyable
 				obj.Bulk.Parent = obj;
 				obj.Bulk.simulate;
 			obj.Transmission = obj.S1.Transmission;
+			obj.Reflection = obj.S1.Reflection;		% Counting only the first surface reflection as other reflections form separate "pulses"
+			obj.Absorption = obj.Bulk.Absorption;
 			obj.Dispersion = obj.S1.Dispersion;
-			if obj.Regime == "T"
+
 				obj.Transmission = obj.Transmission...
 								.* obj.Bulk.Transmission...
 								.* obj.S2.Transmission;
 
+			if obj.Regime == "T"
 				obj.Dispersion = obj.Dispersion...
 							   + obj.Bulk.Dispersion...
 							   + obj.S2.Dispersion;
 			else
-				obj.Transmission = 1 - obj.Transmission;
+				% obj.Transmission = 1 - obj.Transmission;
 			end
 		end
 
@@ -130,9 +135,14 @@ classdef Optic < matlab.mixin.Copyable
 			tl = tiledlayout(fh,2,2);
 
 			nexttile
-			wavplot(obj.SimWin.Lambdanm,obj.Transmission)
+			if strcmp(obj.Regime,"T")
+				wavplot(obj.SimWin.Lambdanm,obj.Transmission)
+				ylabel('Power Transmission')
+			else
+				wavplot(obj.SimWin.Lambdanm,obj.Reflection)
+				ylabel('Power Reflection')
+			end
 			xlim(lims)
-			ylabel('Power Transmission')
 
 			nexttile
 			wavplot(obj.SimWin.Lambdanm,obj.Dispersion)

--- a/toolbox/lib/classes/Optic.m
+++ b/toolbox/lib/classes/Optic.m
@@ -5,6 +5,7 @@ classdef Optic < matlab.mixin.Copyable
 	%
 	%	Sebastian C. Robarts 2023 - sebrobarts@gmail.com
 	properties
+		Name		string
 		Regime		string
 		S1			OpticalSurface
 		Bulk		Dielectric
@@ -160,6 +161,15 @@ classdef Optic < matlab.mixin.Copyable
 			wavplot(obj.SimWin.Lambdanm,obj.GDD*1e30)
 			xlim(lims)
 			ylabel('GDD (fs^2)')
+		end
+
+		function store(obj,name)
+			obj.Name = name;
+			currentfolder = pwd;
+			cd(OptiFaxRoot);
+			cd("objects" + filesep + "optics");
+			save(name,"obj","-mat");
+			cd(currentfolder);
 		end
 
 	end

--- a/toolbox/lib/classes/Optic.m
+++ b/toolbox/lib/classes/Optic.m
@@ -31,8 +31,8 @@ classdef Optic < matlab.mixin.Copyable
 			arguments
 				regimeStr string	= "T"; 
 				s1					= 'None';
-				material			= 'N/A';
-				length_m			= 0;
+				material			= "FS";
+				length_m			= 0.001;
 				theta				= 0;
 				s2					= s1;
 				celsius				= 20;
@@ -44,12 +44,12 @@ classdef Optic < matlab.mixin.Copyable
 				if class(s1) ~= "OpticalSurface"
 					s1 = OpticalSurface(s1,material,theta,1,obj);
 				end
-				if regimeStr == "R"
-					obj.Regime = regimeStr;
-					obj.S1 = s1;
-				elseif regimeStr == "T"
-					obj.Regime = regimeStr;
-					obj.S1 = s1;
+				obj.Regime = regimeStr;
+				obj.S1 = s1;
+				% if regimeStr == "R"
+				% 
+				% elseif regimeStr == "T"
+
 					if class(material) ~= "Dielectric"
 						material = Dielectric(material,length_m,celsius,obj);	
 					end
@@ -58,19 +58,20 @@ classdef Optic < matlab.mixin.Copyable
 					end
 					obj.Bulk = material;
 					obj.S2 = s2;
-				end
+			% 	end
 			end
 		end
 
 		function obj = simulate(obj,simWin)
 			obj.SimWin = simWin;
 			obj.S1.Parent = obj;
+			obj.S2.Parent = obj;
+				obj.Bulk.Parent = obj;
+				obj.Bulk.simulate;
 			obj.Transmission = obj.S1.Transmission;
 			obj.Dispersion = obj.S1.Dispersion;
 			if obj.Regime == "T"
-				obj.Bulk.Parent = obj;
-				obj.Bulk.simulate;
-				obj.S2.Parent = obj;
+
 				obj.Transmission = obj.Transmission...
 								.* obj.Bulk.Transmission...
 								.* obj.S2.Transmission;

--- a/toolbox/lib/classes/Optic.m
+++ b/toolbox/lib/classes/Optic.m
@@ -71,7 +71,6 @@ classdef Optic < matlab.mixin.Copyable
 			obj.Transmission = obj.S1.Transmission;
 			obj.Dispersion = obj.S1.Dispersion;
 			if obj.Regime == "T"
-
 				obj.Transmission = obj.Transmission...
 								.* obj.Bulk.Transmission...
 								.* obj.S2.Transmission;

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -8,7 +8,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 	%	Sebastian C. Robarts 2023 - sebrobarts@gmail.com
 	
 	properties
-		DetectorPosition		% Which cavity optic to collect OC data from
+		DetectorPosition = 0;		% Which cavity optic to collect OC data from
 		Pulse	OpticalPulse	% The pulse object for the cavity field, transient?
 		Source	Laser		% Potentially just a pulse?
 		System	Cavity		% Leaving cavity here for now, but should open up in future
@@ -80,7 +80,9 @@ classdef OpticalSim < matlab.mixin.Copyable
 			obj.TripNumber = 0;
 			obj.Source.simulate(obj.SimWin);	% Will we need to load these objects?
 			obj.System.simulate(obj.SimWin);
-			obj.DetectorPosition = obj.System.OCPosition;
+			if ~obj.DetectorPosition
+				obj.DetectorPosition = obj.System.OCPosition;
+			end
 
 			obj.PumpPulse = copy(obj.Source.Pulse);	% Copy the source pulse to create modifiable pump
 			obj.PumpPulse.Name = "Pump Pulse";
@@ -141,7 +143,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 			obj.InputPulse.copyfrom(obj.PumpPulse);
 			obj.InputPulse.add(obj.Pulse);
 			obj.OutputPulse = copy(obj.Pulse);
-			obj.OutputPulse.Name = ["Detected Pulse (" + obj.System.Optics.(obj.DetectorPosition).Name + ")"];
+			obj.OutputPulse.Name = "Detected Pulse (" + obj.System.Optics.(obj.DetectorPosition).Name + ")";
 
 			while obj.SimTripNumber < obj.RoundTrips
 
@@ -180,13 +182,13 @@ classdef OpticalSim < matlab.mixin.Copyable
 				end
 				% obj.Pulse.refract(airOpt);
 				obj.detect;
-				obj.Pulse.applyGD(obj.Delay);
+
 				if obj.DetectorPosition < width(obj.System.Optics)
 					obj.Pulse.propagate(obj.System.Optics(:,obj.DetectorPosition+1:end));
 				end
+				obj.Pulse.applyGD(obj.Delay);
 
 			end
-
 			obj.FinalPlotter.updateYData((obj.TripNumber-obj.RoundTrips) + (1:obj.RoundTrips));
 			obj.FinalPlotter.roundtripplots;
 

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -189,6 +189,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 		function detect(obj)
 			OCopt = obj.System.Optics.(obj.System.OCPosition);
 			pulseOC = obj.Pulse.outputcouple(OCopt);
+			obj.OutputPulse.copyfrom(pulseOC);
 		end
 		
 		function pump(obj)

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -139,7 +139,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 			obj.InputPulse.copyfrom(obj.PumpPulse);
 			obj.InputPulse.add(obj.Pulse);
 			obj.OutputPulse = copy(obj.Pulse);
-			obj.OutputPulse.Name = "Combined Transmitted Pulse";
+			obj.OutputPulse.Name = "Detected Pulse";
 
 			while obj.SimTripNumber < obj.RoundTrips
 
@@ -173,12 +173,19 @@ classdef OpticalSim < matlab.mixin.Copyable
 				end
 				
 				obj.Pulse.refract(airOpt);
-				obj.OutputPulse.TemporalField = obj.Pulse.TemporalField;
+				% obj.OutputPulse.TemporalField = obj.Pulse.TemporalField;
 			
-				obj.Pulse.propagate(obj.System.Optics);
+				% obj.Pulse.propagate(obj.System.Optics);
+				if obj.System.OCPosition > 1
+					obj.Pulse.propagate(obj.System.Optics(:,1:obj.System.OCPosition-1));
+				end
 				% obj.Pulse.refract(airOpt);
-				obj.OutputPulse.minus(obj.Pulse);
-				obj.Pulse.applyGD(obj.Delay);	
+				% obj.OutputPulse.minus(obj.Pulse);	
+				obj.detect;
+				obj.Pulse.applyGD(obj.Delay);
+				if obj.System.OCPosition < width(obj.System.Optics)
+					obj.Pulse.propagate(obj.System.Optics(:,obj.System.OCPosition+1:end));
+				end
 			end
 
 			obj.FinalPlotter.updateYData((obj.TripNumber-obj.RoundTrips) + (1:obj.RoundTrips));

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -83,13 +83,14 @@ classdef OpticalSim < matlab.mixin.Copyable
 			obj.PumpPulse = copy(obj.Source.Pulse);	% Copy the source pulse to create modifiable pump
 			obj.PumpPulse.Name = "Pump Pulse";
 			obj.convertArrays;	% Convert arrays to correct precision and type
+			
 			obj.PumpPulse.applyGDD(obj.System.PumpChirp);
 			
-			obj.InputPulse = obj.PumpPulse.copyto;
+			obj.InputPulse = obj.PumpPulse.writeto;
 			obj.InputPulse.Name = "Simulation-In Pulse";
-			obj.XInPulse = obj.PumpPulse.copyto;
+			obj.XInPulse = obj.PumpPulse.writeto;
 			obj.XInPulse.Name = "Xtal-In Pulse";
-			obj.XOutPulse = obj.PumpPulse.copyto;
+			obj.XOutPulse = obj.PumpPulse.writeto;
 			obj.XOutPulse.Name = "Xtal-Out Pulse";
 			obj.Pulse = copy(obj.PumpPulse);	% Copy the pump pulse as basis for cavity field
 			obj.Pulse.Name = "Intracavity Pulse";
@@ -111,7 +112,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 			end
 			obj.StepSizeModifiers = obj.convArr(zeros(obj.RoundTrips,obj.System.Xtal.NSteps));
 			obj.PumpPulse.refract(airOpt);
-			obj.StoredPulses = obj.Pulse.copyto;
+			obj.StoredPulses = obj.Pulse.writeto;
 			obj.StoredPulses.addDims([obj.RoundTrips,1]);
 		end
 
@@ -175,7 +176,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 				obj.OutputPulse.TemporalField = obj.Pulse.TemporalField;
 			
 				obj.Pulse.propagate(obj.System.Optics);
-				obj.Pulse.refract(airOpt);
+				% obj.Pulse.refract(airOpt);
 				obj.OutputPulse.minus(obj.Pulse);
 				obj.Pulse.applyGD(obj.Delay);	
 			end
@@ -183,6 +184,16 @@ classdef OpticalSim < matlab.mixin.Copyable
 			obj.FinalPlotter.updateYData((obj.TripNumber-obj.RoundTrips) + (1:obj.RoundTrips));
 			obj.FinalPlotter.roundtripplots;
 
+		end
+
+		function detect(obj)
+			OCopt = obj.System.Optics.(obj.System.OCPosition);
+			if strcmp(OCopt.Regime,"T")
+				obj.OutputPulse.copyfrom(obj.Pulse);	% Temp store 
+				obj.Pulse.propagate(OCopt.S1)
+			else
+				"R"
+			end
 		end
 		
 		function pump(obj)

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -141,7 +141,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 			obj.InputPulse.copyfrom(obj.PumpPulse);
 			obj.InputPulse.add(obj.Pulse);
 			obj.OutputPulse = copy(obj.Pulse);
-			obj.OutputPulse.Name = "Detected Pulse";
+			obj.OutputPulse.Name = ["Detected Pulse (" + obj.System.Optics.(obj.DetectorPosition).Name + ")"];
 
 			while obj.SimTripNumber < obj.RoundTrips
 

--- a/toolbox/lib/classes/OpticalSim.m
+++ b/toolbox/lib/classes/OpticalSim.m
@@ -188,12 +188,7 @@ classdef OpticalSim < matlab.mixin.Copyable
 
 		function detect(obj)
 			OCopt = obj.System.Optics.(obj.System.OCPosition);
-			if strcmp(OCopt.Regime,"T")
-				obj.OutputPulse.copyfrom(obj.Pulse);	% Temp store 
-				obj.Pulse.propagate(OCopt.S1)
-			else
-				"R"
-			end
+			pulseOC = obj.Pulse.outputcouple(OCopt);
 		end
 		
 		function pump(obj)

--- a/toolbox/lib/internal/classes/Dielectric.m
+++ b/toolbox/lib/internal/classes/Dielectric.m
@@ -14,6 +14,7 @@ classdef Dielectric < matlab.mixin.Copyable
 	properties (Dependent)
 		MaterialTFile
 		Transmission
+		Absorption
 		Phi
 		Dispersion
 		PathLength
@@ -88,6 +89,10 @@ classdef Dielectric < matlab.mixin.Copyable
 			% end
 			T = transmission(obj.MaterialTFile,lam,1,nr,frnum,lims(1),lims(2));
 			T = T .^ (obj.PathLength/file_l);
+		end
+
+		function A = get.Absorption(obj)
+			A = 1 - obj.Transmission;
 		end
 
 		function PL = get.PathLength(obj)

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -90,7 +90,7 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			obj.k2t(Ek);
 		end
 
-		function pulseOC = split(obj,optic)
+		function pulseOC = outputcouple(obj,optic)
 			pulseOC = copy(obj);
 			if strcmp(optic.Regime,"T")
 					pulseOC.reflect(optic);

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -76,13 +76,36 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			for ii = 1:width(opt_tbl)
 				opt = opt_tbl.(ii);
 				% Ek = obj.refract(opt);
-				if ii ~= opt.Parent.CrystalPosition
+				if class(opt) ~= "Optic" || ii ~= opt.Parent.CrystalPosition
 					bOp = exp(-1i*opt.Dispersion);
 				end
 				TOp = opt.Transmission .^ 0.5;
 				Ek = TOp .* bOp .* Ek;
 				% obj.k2t(Ek);
 			end
+			obj.k2t(Ek);
+		end
+
+		function pulseOC = split(obj,optic)
+			pulseOC = copy(obj);
+			if class(optic) == "Optic" 
+				if strcmp(optic.Regime,"T")
+					pulseOC.reflect(optic.S1);
+					obj.propagate(optic.S1);
+				else
+					pulseOC.propagate()
+				end
+			else
+				pulseOC.reflect(optic);
+				obj.propagate(optic);
+			end
+		end
+
+		function reflect(obj,optic)
+			RI = 1 - optic.Transmission;
+			RE = RI .^ 0.5;
+			Ek = obj.SpectralField;
+			Ek = Ek .* RE;
 			obj.k2t(Ek);
 		end
 
@@ -268,7 +291,7 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			obj.Medium = pulse.Medium;
 		end
 
-		function pulse = copyto(obj)
+		function pulse = writeto(obj)
 			pulse = copy(obj);
 			pulse.gather;
 		end

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -77,7 +77,7 @@ classdef OpticalPulse < matlab.mixin.Copyable
 				opt = opt_tbl.(ii);
 				% Temp removed due to high overhead of FFTs and no effect on calculated outcome:
 				% Ek = obj.refract(opt);
-				if class(opt) ~= "Optic" || ii ~= opt.Parent.CrystalPosition
+				if class(opt) ~= "NonlinearCrystal"
 					bOp = exp(-1i*opt.Dispersion);
 				end
 				if strcmp(opt.Regime,"T")
@@ -93,11 +93,11 @@ classdef OpticalPulse < matlab.mixin.Copyable
 		function pulseOC = outputcouple(obj,optic)
 			pulseOC = copy(obj);
 			if strcmp(optic.Regime,"T")
-					pulseOC.reflect(optic);
-					obj.transmit(optic);
+				obj.propagate(optic);
+				pulseOC.reflect(optic);
 			else
-					pulseOC.transmit(optic);
-					obj.reflect(optic);
+				obj.propagate(optic);
+				pulseOC.transmit(optic);
 			end
 		end
 
@@ -105,7 +105,7 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			TE = optic.Transmission .^ 0.5;
 			bOp = exp(-1i*optic.Dispersion);
 			Ek = obj.SpectralField;
-			Ek = Ek .* bOp .* TE;
+			Ek = TE .* bOp .* Ek;
 			obj.k2t(Ek);
 		end
 
@@ -113,7 +113,7 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			RE = optic.Reflection .^ 0.5;
 			bOp = exp(-1i*optic.Dispersion);
 			Ek = obj.SpectralField;
-			Ek = Ek .* bOp .* RE;
+			Ek = RE .* bOp .* Ek;
 			obj.k2t(Ek);
 		end
 

--- a/toolbox/lib/internal/classes/OpticalPulse.m
+++ b/toolbox/lib/internal/classes/OpticalPulse.m
@@ -75,37 +75,45 @@ classdef OpticalPulse < matlab.mixin.Copyable
 			Ek = obj.SpectralField;
 			for ii = 1:width(opt_tbl)
 				opt = opt_tbl.(ii);
+				% Temp removed due to high overhead of FFTs and no effect on calculated outcome:
 				% Ek = obj.refract(opt);
 				if class(opt) ~= "Optic" || ii ~= opt.Parent.CrystalPosition
 					bOp = exp(-1i*opt.Dispersion);
 				end
-				TOp = opt.Transmission .^ 0.5;
-				Ek = TOp .* bOp .* Ek;
-				% obj.k2t(Ek);
+				if strcmp(opt.Regime,"T")
+					MagOp = opt.Transmission .^ 0.5;
+				else
+					MagOp = opt.Reflection .^ 0.5;
+				end
+				Ek = MagOp .* bOp .* Ek;
 			end
 			obj.k2t(Ek);
 		end
 
 		function pulseOC = split(obj,optic)
 			pulseOC = copy(obj);
-			if class(optic) == "Optic" 
-				if strcmp(optic.Regime,"T")
-					pulseOC.reflect(optic.S1);
-					obj.propagate(optic.S1);
-				else
-					pulseOC.propagate()
-				end
+			if strcmp(optic.Regime,"T")
+					pulseOC.reflect(optic);
+					obj.transmit(optic);
 			else
-				pulseOC.reflect(optic);
-				obj.propagate(optic);
+					pulseOC.transmit(optic);
+					obj.reflect(optic);
 			end
 		end
 
-		function reflect(obj,optic)
-			RI = 1 - optic.Transmission;
-			RE = RI .^ 0.5;
+		function transmit(obj,optic)
+			TE = optic.Transmission .^ 0.5;
+			bOp = exp(-1i*optic.Dispersion);
 			Ek = obj.SpectralField;
-			Ek = Ek .* RE;
+			Ek = Ek .* bOp .* TE;
+			obj.k2t(Ek);
+		end
+
+		function reflect(obj,optic)
+			RE = optic.Reflection .^ 0.5;
+			bOp = exp(-1i*optic.Dispersion);
+			Ek = obj.SpectralField;
+			Ek = Ek .* bOp .* RE;
 			obj.k2t(Ek);
 		end
 

--- a/toolbox/lib/internal/classes/OpticalSurface.m
+++ b/toolbox/lib/internal/classes/OpticalSurface.m
@@ -28,6 +28,9 @@ classdef OpticalSurface < matlab.mixin.Copyable
 				parent handle = [];
 			end
 			obj.Coating = coatingStr;
+			if class(material) == "Dielectric"
+				material = material.Material;
+			end
 			obj.Material = material;
 			obj.IncidentAngle = theta;
 			obj.Order = order;

--- a/toolbox/lib/internal/classes/OpticalSurface.m
+++ b/toolbox/lib/internal/classes/OpticalSurface.m
@@ -12,6 +12,7 @@ classdef OpticalSurface < matlab.mixin.Copyable
 	end
 	properties (Dependent)
 		Transmission
+		Reflection
 		Dispersion
 	end
 
@@ -51,6 +52,10 @@ classdef OpticalSurface < matlab.mixin.Copyable
 			else
 				T = transmission(obj.Coating,lam);
 			end
+		end
+
+		function R = get.Reflection(obj)
+			R = 1 - obj.Transmission;
 		end
 
 		function phi_rel = get.Dispersion(obj)

--- a/toolbox/lib/internal/plotting/updatepeaks.m
+++ b/toolbox/lib/internal/plotting/updatepeaks.m
@@ -36,7 +36,10 @@ if ~isempty(pks)
 	
 	textGroupH.Children = flip(textGroupH.Children);
 	ymax = textGroupH.Children(maxPkID).Extent(2) + textGroupH.Children(maxPkID).Extent(4);
-	axh.YAxis(1).Limits = [0 1.1*ymax];
+	while ymax > axh.YAxis(1).Limits
+		axh.YAxis(1).Limits = [0 1.1*ymax];
+		ymax = textGroupH.Children(maxPkID).Extent(2) + textGroupH.Children(maxPkID).Extent(4);
+	end
 else
 	ymax = max(y);
 	axh.YAxis(1).Limits = [0 1.1*ymax];

--- a/toolbox/lib/internal/plotting/updatepeaks.m
+++ b/toolbox/lib/internal/plotting/updatepeaks.m
@@ -20,14 +20,15 @@ end
 [pks,locs,fwhps,proms] = findpeaks(y,x,"MinPeakDistance",minDist,"MinPeakProminence",minProm);
 [~,maxPkid] = max(pks);
 
+h = findobj(axh,'Type','hggroup');
+if ishandle(h)
+	delete(h.Children);
+	textGroupH = h;
+else
+	textGroupH = hggroup(axh);
+end
+
 if ~isempty(pks)
-	h = findobj(axh,'Type','hggroup');
-	if ishandle(h)
-		delete(h.Children);
-		textGroupH = h;
-	else
-		textGroupH = hggroup(axh);
-	end
 	pstr = [num2str(locs',"%5.0f")  num2str(pks',",%4.0f")];
 	
 	text(textGroupH,locs-1,pks+1,pstr,'FontSize',7,'HorizontalAlignment','left','Clipping','on',...

--- a/toolbox/lib/internal/plotting/updatepeaks.m
+++ b/toolbox/lib/internal/plotting/updatepeaks.m
@@ -37,5 +37,8 @@ if ~isempty(pks)
 	textGroupH.Children = flip(textGroupH.Children);
 	ymax = textGroupH.Children(maxPkid).Extent(2) + textGroupH.Children(maxPkid).Extent(4);
 	axh.YAxis(1).Limits = [0 1.1*ymax];
+else
+	ymax = max(y);
+	axh.YAxis(1).Limits = [0 1.1*ymax];
 end
 end

--- a/toolbox/lib/internal/plotting/updatepeaks.m
+++ b/toolbox/lib/internal/plotting/updatepeaks.m
@@ -35,6 +35,7 @@ if ~isempty(pks)
 								 	'Rotation',90);
 	
 	textGroupH.Children = flip(textGroupH.Children);
+	axh.YAxis(1).Limits = [0 1];
 	ymax = textGroupH.Children(maxPkID).Extent(2) + textGroupH.Children(maxPkID).Extent(4);
 	while ymax > axh.YAxis(1).Limits
 		axh.YAxis(1).Limits = [0 1.1*ymax];

--- a/toolbox/lib/internal/plotting/updatepeaks.m
+++ b/toolbox/lib/internal/plotting/updatepeaks.m
@@ -18,7 +18,7 @@ if x(1) > x(end)
 end
 
 [pks,locs,fwhps,proms] = findpeaks(y,x,"MinPeakDistance",minDist,"MinPeakProminence",minProm);
-[~,maxPkid] = max(pks);
+[~,maxPkID] = max(pks);
 
 h = findobj(axh,'Type','hggroup');
 if ishandle(h)
@@ -35,7 +35,7 @@ if ~isempty(pks)
 								 	'Rotation',90);
 	
 	textGroupH.Children = flip(textGroupH.Children);
-	ymax = textGroupH.Children(maxPkid).Extent(2) + textGroupH.Children(maxPkid).Extent(4);
+	ymax = textGroupH.Children(maxPkID).Extent(2) + textGroupH.Children(maxPkID).Extent(4);
 	axh.YAxis(1).Limits = [0 1.1*ymax];
 else
 	ymax = max(y);


### PR DESCRIPTION
Properly implemented support for detecting components of the field which exit the cavity at/after a user defined optic. Combining this with the ability to script sequential changes in simulation properties allows the user to collect information from different places in a cavity and retain those plots, before automatically running further round trips and collecting data from the next element of interest.